### PR TITLE
Explicitly set Smoldocling in VLM pipeline

### DIFF
--- a/kubeflow-pipelines/docling-vlm/docling_convert_components.py
+++ b/kubeflow-pipelines/docling-vlm/docling_convert_components.py
@@ -236,6 +236,7 @@ def docling_convert(
     from docling.datamodel.base_models import InputFormat  # pylint: disable=import-outside-toplevel  # noqa: PLC0415, E402
     from docling.datamodel.pipeline_options import (  # pylint: disable=import-outside-toplevel  # noqa: PLC0415, E402
         VlmPipelineOptions,
+        smoldocling_vlm_conversion_options,
     )
     from docling.pipeline.vlm_pipeline import VlmPipeline  # pylint: disable=import-outside-toplevel  # noqa: PLC0415, E402
     from docling.document_converter import DocumentConverter, PdfFormatOption  # pylint: disable=import-outside-toplevel  # noqa: PLC0415, E402
@@ -309,7 +310,9 @@ def docling_convert(
             },
         )
     else:
-        pipeline_options = VlmPipelineOptions()
+        pipeline_options = VlmPipelineOptions(
+            vlm_options=smoldocling_vlm_conversion_options
+        )
 
     pipeline_cls = VlmPipeline
     pipeline_options.artifacts_path = artifacts_path_p

--- a/kubeflow-pipelines/docling-vlm/docling_convert_pipeline_compiled.yaml
+++ b/kubeflow-pipelines/docling-vlm/docling_convert_pipeline_compiled.yaml
@@ -254,14 +254,14 @@ deploymentSpec:
           \ PLC0415, E402\n    from docling.datamodel.base_models import InputFormat\
           \  # pylint: disable=import-outside-toplevel  # noqa: PLC0415, E402\n  \
           \  from docling.datamodel.pipeline_options import (  # pylint: disable=import-outside-toplevel\
-          \  # noqa: PLC0415, E402\n        VlmPipelineOptions,\n    )\n    from docling.pipeline.vlm_pipeline\
-          \ import VlmPipeline  # pylint: disable=import-outside-toplevel  # noqa:\
-          \ PLC0415, E402\n    from docling.document_converter import DocumentConverter,\
-          \ PdfFormatOption  # pylint: disable=import-outside-toplevel  # noqa: PLC0415,\
-          \ E402\n    from docling.datamodel.accelerator_options import AcceleratorDevice,\
-          \ AcceleratorOptions  # pylint: disable=import-outside-toplevel  # noqa:\
-          \ PLC0415, E402\n    from docling.datamodel.pipeline_options_vlm_model import\
-          \ ApiVlmOptions, ResponseFormat # pylint: disable=import-outside-toplevel\
+          \  # noqa: PLC0415, E402\n        VlmPipelineOptions,\n        smoldocling_vlm_conversion_options,\n\
+          \    )\n    from docling.pipeline.vlm_pipeline import VlmPipeline  # pylint:\
+          \ disable=import-outside-toplevel  # noqa: PLC0415, E402\n    from docling.document_converter\
+          \ import DocumentConverter, PdfFormatOption  # pylint: disable=import-outside-toplevel\
+          \  # noqa: PLC0415, E402\n    from docling.datamodel.accelerator_options\
+          \ import AcceleratorDevice, AcceleratorOptions  # pylint: disable=import-outside-toplevel\
+          \  # noqa: PLC0415, E402\n    from docling.datamodel.pipeline_options_vlm_model\
+          \ import ApiVlmOptions, ResponseFormat # pylint: disable=import-outside-toplevel\
           \  # noqa: PLC0415, E402\n\n    input_path_p = Path(input_path.path)\n \
           \   artifacts_path_p = Path(artifacts_path.path)\n    output_path_p = Path(output_path.path)\n\
           \    output_path_p.mkdir(parents=True, exist_ok=True)\n\n    input_pdfs\
@@ -303,7 +303,8 @@ deploymentSpec:
           \                ),\n            ),\n            prompt=\"OCR the full page\
           \ to markdown.\",\n            timeout=600,\n            response_format=ResponseFormat.MARKDOWN,\n\
           \            headers={\n                \"Authorization\": f\"Bearer {remote_model_api_key}\"\
-          ,\n            },\n        )\n    else:\n        pipeline_options = VlmPipelineOptions()\n\
+          ,\n            },\n        )\n    else:\n        pipeline_options = VlmPipelineOptions(\n\
+          \            vlm_options=smoldocling_vlm_conversion_options\n        )\n\
           \n    pipeline_cls = VlmPipeline\n    pipeline_options.artifacts_path =\
           \ artifacts_path_p\n    pipeline_options.document_timeout = float(timeout_per_document)\n\
           \    pipeline_options.accelerator_options = AcceleratorOptions(\n      \

--- a/kubeflow-pipelines/docling-vlm/local_run.py
+++ b/kubeflow-pipelines/docling-vlm/local_run.py
@@ -1,0 +1,48 @@
+from typing import List
+
+from kfp import dsl, local
+
+from docling_convert_components import (
+    create_pdf_splits,
+    docling_convert,
+    download_docling_models,
+    import_pdfs,
+)
+
+
+@dsl.component(base_image="python:3.11")
+def take_first_split(splits: List[List[str]]) -> List[str]:
+    return splits[0] if splits else []
+
+
+@dsl.pipeline()
+def convert_pipeline_local():
+    importer = import_pdfs(
+        filenames="2305.03393v1-pg9.pdf",
+        base_url="https://github.com/docling-project/docling/raw/v2.43.0/tests/data/pdf",
+    )
+
+    pdf_splits = create_pdf_splits(
+        input_path=importer.outputs["output_path"],
+        num_splits=1,
+    )
+
+    artifacts = download_docling_models(remote_model_endpoint_enabled=False)
+
+    first_split = take_first_split(splits=pdf_splits.output)
+
+    docling_convert(
+        input_path=importer.outputs["output_path"],
+        artifacts_path=artifacts.outputs["output_path"],
+        pdf_filenames=first_split.output,
+    )
+
+
+def main() -> None:
+    # Requires: pip install docker; and a Docker-compatible daemon (Docker or Podman socket)
+    local.init(runner=local.DockerRunner())
+    convert_pipeline_local()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

### Fixes a regression

Docling recently switched its default VLM model from `smoldocling` to `granite-docling`, so we need to explicitly set it if we'd like to use the former. In future, we'll perform tests to consider switching to Granite Docling. This PR also adds a local runner for the VLM pipeline.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a runnable local workflow to convert PDFs end-to-end using Docker-based execution.
  - Included a helper to select the first PDF split for streamlined processing.
  - Provided a script entry point to quickly run the pipeline locally.

- Improvements
  - Standardized VLM conversion with a predefined configuration for more consistent results.
  - Updated the compiled pipeline to reflect the new VLM configuration path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->