### PR TITLE
Improve Makefile targets and add dev dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format-python format-notebook format-python-check format-notebooks-check test-notebook-parameters test-notebook-execution test-kfp-components test-notebooks test-all
+.PHONY: test unittest integration-test test-all test-notebook-parameters test-notebook-execution test-notebooks format-python format-notebooks lint-python format-python-check format-notebooks-check typecheck lint coverage help
 
 USE_CASES := $(wildcard notebooks/use-cases/*.ipynb)
 TUTORIALS := $(wildcard notebooks/tutorials/*.ipynb)
@@ -9,36 +9,55 @@ DOCLING_STANDARD_PIPELINE := $(wildcard kubeflow-pipelines/docling-standard/*.py
 DOCLING_VLM_PIPELINE := $(wildcard kubeflow-pipelines/docling-vlm/*.py)
 ALL_PYTHON_FILES := $(COMMON) $(DOCLING_STANDARD_PIPELINE) $(DOCLING_VLM_PIPELINE)
 
-format-python:
-	@echo "Running ruff format..."
+##@ Testing
+
+test:                          ## Run all tests (unit + integration)
+	pytest tests/ -v
+
+unittest:                      ## Run unit tests only (no GPU, network, or Docker needed)
+	pytest tests/unit/ -v
+
+integration-test:              ## Run integration tests (notebook execution, may need GPU)
+	pytest tests/integration/ -v
+
+test-notebook-parameters:      ## Validate notebooks have papermill 'parameters' cell
+	pytest tests/integration/test_notebook_parameters.py -v
+
+test-notebook-execution:       ## Execute all notebooks via papermill (slow, may need GPU)
+	pytest tests/integration/test_notebook_execution.py -v
+
+test-notebooks: format-notebooks-check test-notebook-parameters test-notebook-execution  ## Run all notebook validations (formatting, parameters, execution)
+
+coverage:                      ## Run unit tests with coverage report
+	pytest tests/unit/ --cov --cov-report=term-missing --cov-report=html
+
+test-all: lint typecheck test  ## Run everything: lint + typecheck + all tests
+
+##@ Formatting
+
+format-python:                 ## Auto-format Python files with ruff
 	ruff format $(ALL_PYTHON_FILES)
 
-format-notebooks:
-	@echo "Running nbstripout..."
+format-notebooks:              ## Strip notebook outputs with nbstripout
 	nbstripout --keep-id $(ALL_NOTEBOOKS)
 
-format-notebooks-check:
+##@ Checks
+
+lint-python:                   ## Run ruff linter on all Python files
+	ruff check scripts/ tests/ kubeflow-pipelines/
+
+format-python-check:           ## Check Python formatting (ruff, no changes)
+	ruff format --check scripts/ tests/ kubeflow-pipelines/
+
+format-notebooks-check:        ## Check notebook outputs are stripped
 	nbstripout --keep-id --verify $(ALL_NOTEBOOKS)
-	@echo "nbstripout check passed :)"
 
-format-python-check:
-	ruff format --check $(ALL_PYTHON_FILES)
-	@echo "ruff format check passed :)"
+typecheck:                     ## Run mypy type checks
+	mypy scripts/ tests/ kubeflow-pipelines/
 
-test-notebook-parameters:
-	@echo "Running notebook parameters validation..."
-	pytest tests/test_notebook_parameters.py -v
-	@echo "Notebook parameters test passed :)"
+lint: lint-python format-python-check format-notebooks-check  ## Run all lint + format checks
 
-test-notebook-execution:
-	@echo "Running notebook execution tests..."
-	pytest tests/test_notebook_execution.py -v
-	@echo "Notebook execution tests passed :)"
+##@ Help
 
-test-notebooks: format-notebooks-check test-notebook-parameters test-notebook-execution
-	@echo "All notebook validations completed successfully (formatting, parameters, execution) :)"
-
-test-all: test-notebooks format-python-check
-	@echo "Running all tests..."
-	pytest tests/ -v
-	@echo "All tests passed :)"
+help:                          ## Show this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,9 @@
 ruff>=0.1.0
-nbstripout>=0.6.0  
+nbstripout>=0.6.0
 pytest>=7.0.0
 nbformat>=5.7.0
 papermill>=2.4.0
 ipykernel>=6.20.0
 jupyter>=1.0.0
+mypy>=1.10.0
+pytest-cov>=4.1.0


### PR DESCRIPTION
## Summary

- Restructure Makefile with categorized targets (`##@ Testing`, `##@ Formatting`, `##@ Checks`) and `make help`
- Add granular test targets: `test`, `unittest`, `integration-test`, `coverage`, `test-all`
- Add `lint-python` (ruff check), `typecheck` (mypy), and composite `lint` target
- Expand scope from `kubeflow-pipelines/` only to all Python directories (`scripts/`, `tests/`, `kubeflow-pipelines/`)
- Add `mypy>=1.10.0` and `pytest-cov>=4.1.0` to `requirements-dev.txt`

## Context

Part of [AI Bug Automation Readiness](https://github.com/ugiordan/ai-bug-automation-readiness/blob/main/docs/TEAM_ACTION_GUIDE.md) assessment — Task 8: Build/Dependency Setup.

A single `make help` command now shows all available targets with descriptions, making the project immediately navigable for new contributors and AI tools.

## Test plan

- [ ] `make help` shows categorized target list
- [ ] `make unittest` runs unit tests
- [ ] `make lint` runs ruff check + format check + nbstripout check
- [ ] `pip install -r requirements-dev.txt` installs all dev dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)