### PR TITLE
Add mypy type checking configuration and CI workflow

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,33 @@
+name: Type Check (mypy)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "**/*.py"
+      - "pyproject.toml"
+      - "requirements-dev.txt"
+      - ".github/workflows/typecheck.yml"
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install type checking dependencies
+        run: |
+          pip install mypy
+          # Install type stubs for standard library and common packages
+          pip install types-requests
+
+      - name: Run mypy
+        run: make typecheck

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,56 @@ lint.ignore = ["E203","E501","UP006","UP007","UP035"]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = ["--tb=short", "-v"]
+
+[tool.mypy]
+python_version = "3.12"
+warn_return_any = true
+warn_unused_configs = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+check_untyped_defs = true
+disallow_untyped_defs = false
+disallow_incomplete_defs = true
+no_implicit_optional = true
+strict_equality = true
+show_error_codes = true
+show_column_numbers = true
+
+# Exclude generated and non-source files
+exclude = [
+  "venv/",
+  "\\.venv/",
+  "\\.ipynb_checkpoints/",
+  "local_outputs/",
+]
+
+# -- Per-module overrides --
+
+# KFP components: imports happen inside function bodies and reference
+# packages only available in the container base image (docling, etc.).
+# These cannot be resolved locally, so we suppress import errors.
+[[tool.mypy.overrides]]
+module = [
+  "kubeflow-pipelines.common.components",
+  "kubeflow-pipelines.docling-standard.standard_components",
+  "kubeflow-pipelines.docling-vlm.vlm_components",
+]
+disable_error_code = ["import-not-found"]
+
+# Third-party libraries without type stubs
+[[tool.mypy.overrides]]
+module = [
+  "kfp.*",
+  "docling.*",
+  "docling_core.*",
+  "datasets",
+  "h5py",
+  "jinja2",
+  "papermill",
+  "nbformat",
+  "nbformat.*",
+  "submodlib",
+  "transformers",
+  "tqdm",
+]
+ignore_missing_imports = true


### PR DESCRIPTION
## Summary

- Add `[tool.mypy]` configuration to `pyproject.toml` with graduated strictness
- Add `typecheck.yml` GitHub Actions workflow to run mypy on PRs with Python changes
- Per-module overrides for KFP components (suppress import-not-found for inline imports)
- Per-module overrides for third-party libraries without type stubs (kfp, docling, h5py, etc.)

## Context

Part of [AI Bug Automation Readiness](https://github.com/ugiordan/ai-bug-automation-readiness/blob/main/docs/TEAM_ACTION_GUIDE.md) assessment — Task 9: Type Safety.

Key mypy settings:
- `check_untyped_defs = true` — checks function bodies even without annotations
- `disallow_untyped_defs = false` — doesn't require annotations (pragmatic for existing codebase)
- `no_implicit_optional = true` — requires explicit `Optional[X]`

## Test plan

- [ ] `mypy scripts/ tests/ kubeflow-pipelines/` runs without configuration errors
- [ ] CI workflow triggers on PRs with `.py` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)