### PR TITLE
Add ruff linting to CI alongside format checking

### DIFF
--- a/.github/workflows/validate-python.yml
+++ b/.github/workflows/validate-python.yml
@@ -1,4 +1,4 @@
-name: Python Formatting Validation
+name: Python Lint & Format
 
 on:
   workflow_dispatch:
@@ -9,35 +9,26 @@ on:
       - ".pre-commit-config.yaml"
       - "Makefile"
       - "pyproject.toml"
-      - ".github/workflow/validate-python.yml"
-  pull_request_target:
-    types: [closed]
-    paths:
-      - "**/*.py"
-      - ".pre-commit-config.yaml"
-      - "Makefile"
-      - "pyproject.toml"
-      - ".github/workflow/validate-python.yml"
+      - ".github/workflows/validate-python.yml"
 
 jobs:
-  formatting-test:
+  lint-and-format:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          # For pull_request_target on forks, ensure we check out the merge commit or default branch safely
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - name: Install python formatting test dependencies
+      - name: Install ruff
         run: pip install ruff
 
-      - name: Run Formatting Tests
-        run: make format-python-check
+      - name: Run ruff linter
+        run: ruff check scripts/ tests/ kubeflow-pipelines/
+
+      - name: Run ruff format check
+        run: ruff format --check scripts/ tests/ kubeflow-pipelines/

--- a/docs/linting-in-ci.md
+++ b/docs/linting-in-ci.md
@@ -1,0 +1,92 @@
+# Linting in CI
+
+> Principle: Automated code style enforcement catches formatting issues in AI-generated code.
+
+## Gap
+
+The existing `validate-python.yml` only ran `ruff format --check` — this checks **formatting** (whitespace, line length, quote style) but not **linting** (actual code issues: unused imports, undefined names, mutable default arguments, missing imports, deprecated syntax).
+
+The Makefile `lint` target had the same gap, and only covered `kubeflow-pipelines/` files — missing `scripts/` and `tests/`.
+
+| What | Formatting (`ruff format`) | Linting (`ruff check`) |
+|---|---|---|
+| Catches style/whitespace | Yes | No |
+| Catches undefined names | No | Yes (F821) |
+| Catches unused imports | No | Yes (F401) |
+| Catches mutable defaults | No | Yes (B006) |
+| Catches import ordering | No | Yes (I) |
+| Catches deprecated syntax | No | Yes (UP) |
+
+## Changes
+
+### 1. `validate-python.yml` — Added `ruff check` step
+
+```yaml
+- name: Run ruff linter
+  run: ruff check scripts/ tests/ kubeflow-pipelines/
+
+- name: Run ruff format check
+  run: ruff format --check scripts/ tests/ kubeflow-pipelines/
+```
+
+Also:
+- Renamed workflow from "Python Formatting Validation" to "Python Lint & Format"
+- Removed `pull_request_target` trigger (security concern flagged in earlier audit)
+- Expanded scope from `$(ALL_PYTHON_FILES)` (kubeflow-pipelines only) to all Python directories
+
+### 2. Makefile — Added `lint-python` target
+
+```makefile
+lint-python:                   ## Run ruff linter on all Python files
+	ruff check scripts/ tests/ kubeflow-pipelines/
+```
+
+Updated `lint` target to include linting:
+```makefile
+lint: lint-python format-python-check format-notebooks-check
+```
+
+Updated `format-python-check` to cover all directories:
+```makefile
+format-python-check:
+	ruff format --check scripts/ tests/ kubeflow-pipelines/
+```
+
+### 3. Ruff rules (already configured)
+
+The `pyproject.toml` already had comprehensive lint rules — they just weren't being run in CI:
+
+```toml
+lint.select = ["E","F","I","B","W","UP"]
+```
+
+| Rule | What it catches |
+|---|---|
+| E | pycodestyle errors |
+| F | pyflakes (undefined names, unused imports, redefined variables) |
+| I | import sorting (isort-compatible) |
+| B | flake8-bugbear (common bug patterns) |
+| W | warnings |
+| UP | pyupgrade (modernize syntax for Python 3.12) |
+
+## CI Pipeline After Change
+
+```
+PR opened
+  → validate-python.yml
+      1. ruff check (LINT)        ← NEW
+      2. ruff format --check (FORMAT)
+  → ci.yml
+      3. pytest tests/unit/ (UNIT TESTS)
+      4. pytest test_notebook_parameters.py
+  → typecheck.yml
+      5. mypy (TYPE CHECK)
+```
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `.github/workflows/validate-python.yml` | Added `ruff check` step, removed `pull_request_target`, expanded file scope |
+| `Makefile` | Added `lint-python` target, updated `lint` to include it, expanded `format-python-check` scope |
+| `CLAUDE.md` | Updated CI table and lint command descriptions |


### PR DESCRIPTION
## Summary

- Add `ruff check` step to `validate-python.yml` (catches unused imports, undefined names, mutable defaults, etc.)
- Rename workflow from "Python Formatting Validation" to "Python Lint & Format"
- Remove `pull_request_target` trigger (security concern)
- Expand scope to all Python directories (`scripts/`, `tests/`, `kubeflow-pipelines/`)

## Context

Part of [AI Bug Automation Readiness](https://github.com/ugiordan/ai-bug-automation-readiness/blob/main/docs/TEAM_ACTION_GUIDE.md) assessment — Task 17: Linting in CI.

Previously, CI only ran `ruff format --check` (formatting) but not `ruff check` (linting). These catch fundamentally different issues — see `docs/linting-in-ci.md` for details.

## Test plan

- [ ] CI triggers on PRs with `.py` changes
- [ ] `ruff check scripts/ tests/ kubeflow-pipelines/` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)