### PR TITLE
Add CODEOWNERS for automatic PR reviewer assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,37 @@
-# Default owners for everything
-*  @opendatahub-io/odh-data-processing
+# CODEOWNERS — automatic reviewer assignment for PRs
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Rules are evaluated bottom-up: the last matching pattern takes precedence.
+# Each PR requires approval from at least one owner of every changed file.
 
-# Keep the CODEOWNERS file itself owned by the team
-/.github/CODEOWNERS  @opendatahub-io/odh-data-processing
+# ── Default: team owns everything ──────────────────────────────────────
+*                                          @opendatahub-io/odh-data-processing
+
+# ── KFP Pipelines ─────────────────────────────────────────────────────
+# Shared components, constants, and pipeline definitions
+kubeflow-pipelines/                        @opendatahub-io/odh-data-processing-pipelines
+
+# ── Notebooks ──────────────────────────────────────────────────────────
+notebooks/                                 @opendatahub-io/odh-data-processing-notebooks
+
+# ── Subset Selection ──────────────────────────────────────────────────
+scripts/subset_selection/                  @opendatahub-io/odh-data-processing-ml
+
+# ── CI/CD & Repo Config ──────────────────────────────────────────────
+# Changes to CI, hooks, and repo config need core team review
+.github/                                   @opendatahub-io/odh-data-processing
+.pre-commit-config.yaml                    @opendatahub-io/odh-data-processing
+Makefile                                   @opendatahub-io/odh-data-processing
+pyproject.toml                             @opendatahub-io/odh-data-processing
+requirements-dev.txt                       @opendatahub-io/odh-data-processing
+
+# ── Tests ─────────────────────────────────────────────────────────────
+tests/                                     @opendatahub-io/odh-data-processing
+
+# ── Documentation ─────────────────────────────────────────────────────
+docs/                                      @opendatahub-io/odh-data-processing
+*.md                                       @opendatahub-io/odh-data-processing
+
+# ── Protected files ───────────────────────────────────────────────────
+# CODEOWNERS itself requires core team approval
+.github/CODEOWNERS                         @opendatahub-io/odh-data-processing


### PR DESCRIPTION
## Summary

- Add granular `.github/CODEOWNERS` with per-subsystem ownership
- `kubeflow-pipelines/` → `@opendatahub-io/odh-data-processing-pipelines`
- `notebooks/` → `@opendatahub-io/odh-data-processing-notebooks`
- `scripts/subset_selection/` → `@opendatahub-io/odh-data-processing-ml`
- CI/CD config, tests, docs → `@opendatahub-io/odh-data-processing` (core team)
- CODEOWNERS itself requires core team approval

## Context

Part of [AI Bug Automation Readiness](https://github.com/ugiordan/ai-bug-automation-readiness/blob/main/docs/TEAM_ACTION_GUIDE.md) assessment — Task 19: Code Ownership.

**Note**: Team names are placeholders. Adjust to match actual GitHub team slugs in the `opendatahub-io` organization.

## Test plan

- [ ] GitHub recognizes CODEOWNERS syntax (check Settings > Branches)
- [ ] PRs touching `kubeflow-pipelines/` auto-request review from pipelines team

🤖 Generated with [Claude Code](https://claude.com/claude-code)