### PR TITLE
Improve Makefile with KFP-focused targets and help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format-python format-notebook format-python-check format-notebooks-check test-notebook-parameters test-notebook-execution test-kfp-components test-notebooks test-all
+.PHONY: test unittest integration-test test-all test-notebook-parameters test-notebook-execution test-notebooks format-python format-notebooks lint-python format-python-check format-notebooks-check typecheck lint coverage help
 
 USE_CASES := $(wildcard notebooks/use-cases/*.ipynb)
 TUTORIALS := $(wildcard notebooks/tutorials/*.ipynb)
@@ -9,36 +9,55 @@ DOCLING_STANDARD_PIPELINE := $(wildcard kubeflow-pipelines/docling-standard/*.py
 DOCLING_VLM_PIPELINE := $(wildcard kubeflow-pipelines/docling-vlm/*.py)
 ALL_PYTHON_FILES := $(COMMON) $(DOCLING_STANDARD_PIPELINE) $(DOCLING_VLM_PIPELINE)
 
-format-python:
-	@echo "Running ruff format..."
+##@ Testing
+
+test:                          ## Run all tests (unit + integration)
+	pytest tests/ -v
+
+unittest:                      ## Run unit tests only (no GPU, network, or Docker needed)
+	pytest tests/unit/ -v
+
+integration-test:              ## Run integration tests (notebook execution, may need GPU)
+	pytest tests/integration/ -v
+
+test-notebook-parameters:      ## Validate notebooks have papermill 'parameters' cell
+	pytest tests/test_notebook_parameters.py -v
+
+test-notebook-execution:       ## Execute all notebooks via papermill (slow, may need GPU)
+	pytest tests/test_notebook_execution.py -v
+
+test-notebooks: format-notebooks-check test-notebook-parameters test-notebook-execution  ## Run all notebook validations
+
+coverage:                      ## Run unit tests with coverage report
+	pytest tests/unit/ --cov --cov-report=term-missing --cov-report=html
+
+test-all: lint test            ## Run everything: lint + all tests
+
+##@ Formatting
+
+format-python:                 ## Auto-format Python files with ruff
 	ruff format $(ALL_PYTHON_FILES)
 
-format-notebooks:
-	@echo "Running nbstripout..."
+format-notebooks:              ## Strip notebook outputs with nbstripout
 	nbstripout --keep-id $(ALL_NOTEBOOKS)
 
-format-notebooks-check:
-	nbstripout --keep-id --verify $(ALL_NOTEBOOKS)
-	@echo "nbstripout check passed :)"
+##@ Checks
 
-format-python-check:
+lint-python:                   ## Run ruff linter on KFP Python files
+	ruff check kubeflow-pipelines/
+
+format-python-check:           ## Check Python formatting (ruff, no changes)
 	ruff format --check $(ALL_PYTHON_FILES)
-	@echo "ruff format check passed :)"
 
-test-notebook-parameters:
-	@echo "Running notebook parameters validation..."
-	pytest tests/test_notebook_parameters.py -v
-	@echo "Notebook parameters test passed :)"
+format-notebooks-check:        ## Check notebook outputs are stripped
+	nbstripout --keep-id --verify $(ALL_NOTEBOOKS)
 
-test-notebook-execution:
-	@echo "Running notebook execution tests..."
-	pytest tests/test_notebook_execution.py -v
-	@echo "Notebook execution tests passed :)"
+typecheck:                     ## Run mypy type checks on KFP code
+	mypy kubeflow-pipelines/
 
-test-notebooks: format-notebooks-check test-notebook-parameters test-notebook-execution
-	@echo "All notebook validations completed successfully (formatting, parameters, execution) :)"
+lint: lint-python format-python-check  ## Run all lint + format checks
 
-test-all: test-notebooks format-python-check
-	@echo "Running all tests..."
-	pytest tests/ -v
-	@echo "All tests passed :)"
+##@ Help
+
+help:                          ## Show this help message
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,5 @@ nbformat>=5.7.0
 papermill>=2.4.0
 ipykernel>=6.20.0
 jupyter>=1.0.0
+mypy>=1.10.0
+pytest-cov>=4.1.0


### PR DESCRIPTION
## Summary

- Add categorized Makefile targets: `unittest`, `integration-test`, `coverage`, `test-all`, `lint-python`, `typecheck`, `help`
- `lint-python` runs `ruff check` on `kubeflow-pipelines/`
- `typecheck` runs `mypy` on `kubeflow-pipelines/`
- `make help` shows all targets with descriptions
- Add `mypy>=1.10.0` and `pytest-cov>=4.1.0` to `requirements-dev.txt`
- Preserves all existing notebook targets

## Context

Part of [AI Bug Automation Readiness](https://github.com/ugiordan/ai-bug-automation-readiness/blob/main/docs/TEAM_ACTION_GUIDE.md) assessment — Task 8: Build/Dependency Setup.

## Test plan

- [ ] `make help` shows categorized target list
- [ ] `make lint-python` runs ruff check on kubeflow-pipelines/
- [ ] `pip install -r requirements-dev.txt` installs all dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)