### PR TITLE
Add mypy type checking for KFP pipelines

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,32 @@
+name: Type Check (mypy)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "kubeflow-pipelines/**/*.py"
+      - "pyproject.toml"
+      - "requirements-dev.txt"
+      - ".github/workflows/typecheck.yml"
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install type checking dependencies
+        run: |
+          pip install mypy
+          pip install types-requests
+
+      - name: Run mypy on kubeflow-pipelines
+        run: mypy kubeflow-pipelines/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,44 @@ lint.ignore = ["E203","E501","UP006","UP007","UP035"]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = ["--tb=short", "-v"]
+
+[tool.mypy]
+python_version = "3.12"
+warn_return_any = true
+warn_unused_configs = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+check_untyped_defs = true
+disallow_untyped_defs = false
+disallow_incomplete_defs = true
+no_implicit_optional = true
+strict_equality = true
+show_error_codes = true
+show_column_numbers = true
+
+# Exclude generated and non-source files
+exclude = [
+  "venv/",
+  "\\.venv/",
+  "\\.ipynb_checkpoints/",
+  "local_outputs/",
+]
+
+# KFP components: imports happen inside function bodies and reference
+# packages only available in the container base image (docling, etc.).
+[[tool.mypy.overrides]]
+module = [
+  "kubeflow-pipelines.common.components",
+  "kubeflow-pipelines.docling-standard.standard_components",
+  "kubeflow-pipelines.docling-vlm.vlm_components",
+]
+disable_error_code = ["import-not-found"]
+
+# Third-party libraries without type stubs
+[[tool.mypy.overrides]]
+module = [
+  "kfp.*",
+  "docling.*",
+  "docling_core.*",
+]
+ignore_missing_imports = true


### PR DESCRIPTION
## Summary

- Add `[tool.mypy]` configuration to `pyproject.toml` with graduated strictness
- Per-module overrides for KFP components (`disable_error_code = ["import-not-found"]`)
- Per-module overrides for third-party libraries (kfp, docling)
- Add `typecheck.yml` workflow triggered on PRs with `kubeflow-pipelines/**/*.py` changes

## Context

Part of [AI Bug Automation Readiness](https://github.com/ugiordan/ai-bug-automation-readiness/blob/main/docs/TEAM_ACTION_GUIDE.md) assessment — Task 9: Type Safety.

Key settings: `check_untyped_defs = true` (checks function bodies), `disallow_untyped_defs = false` (doesn't require annotations).

## Test plan

- [ ] `mypy kubeflow-pipelines/` runs without configuration errors
- [ ] CI workflow triggers on PRs with KFP code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated automated type checking validation into the development workflow that triggers on code changes and pull requests.
  * Updated development configuration to apply type safety standards and validation rules across the Python codebase with module-specific overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->