### PR TITLE
Add unit tests for KFP constants and pipeline structure

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,8 @@
+"""Auto-apply 'unit' marker to all tests in this directory."""
+
+import pytest
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        item.add_marker(pytest.mark.unit)

--- a/tests/unit/test_kfp_constants.py
+++ b/tests/unit/test_kfp_constants.py
@@ -1,0 +1,55 @@
+"""Tests for KFP pipeline constants."""
+
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+
+# Add kubeflow-pipelines to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "kubeflow-pipelines"))
+
+
+class TestBaseImageConstants:
+    """Test that base image constants are properly configured."""
+
+    def test_python_base_image_has_default(self):
+        """PYTHON_BASE_IMAGE should have a non-empty default."""
+        # Re-import to get fresh defaults (without env var override)
+        with mock.patch.dict(os.environ, {}, clear=True):
+            # Force reimport
+            if "common.constants" in sys.modules:
+                del sys.modules["common.constants"]
+            from common.constants import PYTHON_BASE_IMAGE
+
+            assert PYTHON_BASE_IMAGE
+            assert "python" in PYTHON_BASE_IMAGE.lower()
+
+    def test_docling_base_image_has_default(self):
+        """DOCLING_BASE_IMAGE should have a non-empty default."""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            if "common.constants" in sys.modules:
+                del sys.modules["common.constants"]
+            from common.constants import DOCLING_BASE_IMAGE
+
+            assert DOCLING_BASE_IMAGE
+            assert "docling" in DOCLING_BASE_IMAGE.lower()
+
+    def test_python_base_image_overridable_via_env(self):
+        """PYTHON_BASE_IMAGE should be overridable via environment variable."""
+        custom_image = "my-registry/python:3.12"
+        with mock.patch.dict(os.environ, {"PYTHON_BASE_IMAGE": custom_image}):
+            if "common.constants" in sys.modules:
+                del sys.modules["common.constants"]
+            from common.constants import PYTHON_BASE_IMAGE
+
+            assert PYTHON_BASE_IMAGE == custom_image
+
+    def test_docling_base_image_overridable_via_env(self):
+        """DOCLING_BASE_IMAGE should be overridable via environment variable."""
+        custom_image = "my-registry/docling:latest"
+        with mock.patch.dict(os.environ, {"DOCLING_BASE_IMAGE": custom_image}):
+            if "common.constants" in sys.modules:
+                del sys.modules["common.constants"]
+            from common.constants import DOCLING_BASE_IMAGE
+
+            assert DOCLING_BASE_IMAGE == custom_image

--- a/tests/unit/test_pipeline_compilation.py
+++ b/tests/unit/test_pipeline_compilation.py
@@ -1,0 +1,68 @@
+"""Tests that verify pipeline compilation artifacts exist and are valid."""
+
+from pathlib import Path
+
+import pytest
+
+PIPELINES_DIR = Path(__file__).parent.parent.parent / "kubeflow-pipelines"
+
+
+class TestCompiledYamlExists:
+    """Verify that compiled YAML files exist for each pipeline."""
+
+    def test_standard_compiled_yaml_exists(self):
+        """Standard pipeline compiled YAML should exist."""
+        compiled = PIPELINES_DIR / "docling-standard" / "standard_convert_pipeline_compiled.yaml"
+        assert compiled.exists(), f"Missing compiled YAML: {compiled}"
+
+    def test_vlm_compiled_yaml_exists(self):
+        """VLM pipeline compiled YAML should exist."""
+        compiled = PIPELINES_DIR / "docling-vlm" / "vlm_convert_pipeline_compiled.yaml"
+        assert compiled.exists(), f"Missing compiled YAML: {compiled}"
+
+    def test_standard_compiled_yaml_not_empty(self):
+        """Standard pipeline compiled YAML should not be empty."""
+        compiled = PIPELINES_DIR / "docling-standard" / "standard_convert_pipeline_compiled.yaml"
+        assert compiled.stat().st_size > 0, "Compiled YAML is empty"
+
+    def test_vlm_compiled_yaml_not_empty(self):
+        """VLM pipeline compiled YAML should not be empty."""
+        compiled = PIPELINES_DIR / "docling-vlm" / "vlm_convert_pipeline_compiled.yaml"
+        assert compiled.stat().st_size > 0, "Compiled YAML is empty"
+
+
+class TestPipelineSourceFiles:
+    """Verify pipeline source files exist."""
+
+    @pytest.mark.parametrize("pipeline,filename", [
+        ("docling-standard", "standard_convert_pipeline.py"),
+        ("docling-standard", "standard_components.py"),
+        ("docling-vlm", "vlm_convert_pipeline.py"),
+        ("docling-vlm", "vlm_components.py"),
+    ])
+    def test_pipeline_source_exists(self, pipeline, filename):
+        """Each pipeline should have its source files."""
+        source = PIPELINES_DIR / pipeline / filename
+        assert source.exists(), f"Missing source: {source}"
+
+    @pytest.mark.parametrize("filename", [
+        "components.py",
+        "constants.py",
+        "__init__.py",
+    ])
+    def test_common_module_exists(self, filename):
+        """Common module should have all required files."""
+        source = PIPELINES_DIR / "common" / filename
+        assert source.exists(), f"Missing common file: {source}"
+
+    def test_each_pipeline_has_local_run(self):
+        """Each pipeline should have a local_run.py for local testing."""
+        for pipeline in ["docling-standard", "docling-vlm"]:
+            local_run = PIPELINES_DIR / pipeline / "local_run.py"
+            assert local_run.exists(), f"Missing local_run.py in {pipeline}"
+
+    def test_each_pipeline_has_requirements(self):
+        """Each pipeline should have its own requirements.txt."""
+        for pipeline in ["docling-standard", "docling-vlm"]:
+            reqs = PIPELINES_DIR / pipeline / "requirements.txt"
+            assert reqs.exists(), f"Missing requirements.txt in {pipeline}"


### PR DESCRIPTION
## Summary

- Add `tests/unit/` directory with auto-applied `@pytest.mark.unit` via conftest.py
- `test_kfp_constants.py` — 4 tests for base image constants (defaults, env var overrides)
- `test_pipeline_compilation.py` — 10 tests for pipeline structure (compiled YAML, source files, local_run.py, requirements.txt)
- All tests are fast, no GPU/network/Docker needed

## Context

Part of [AI Bug Automation Readiness](https://github.com/ugiordan/ai-bug-automation-readiness/blob/main/docs/TEAM_ACTION_GUIDE.md) assessment — Task 11: Test-to-Source Ratio.

## Test plan

- [ ] `pytest tests/unit/ -v` passes all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)