### PR TITLE
Register pytest markers for unit and integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,7 @@ lint.ignore = ["E203","E501","UP006","UP007","UP035"]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = ["--tb=short", "-v"]
+markers = [
+  "unit: Fast unit tests with no external dependencies (GPU, network, cluster)",
+  "integration: Tests requiring external resources (notebook execution, GPU, Docker)",
+]


### PR DESCRIPTION
## Summary

- Register `unit` and `integration` pytest markers in `pyproject.toml`
- Enables `pytest -m unit` and `pytest -m integration` without warnings

## Context

Part of [AI Bug Automation Readiness](https://github.com/ugiordan/ai-bug-automation-readiness/blob/main/docs/TEAM_ACTION_GUIDE.md) assessment — Task 12: One-Command Test Execution.

## Test plan

- [ ] `pytest --co -q` runs without marker warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)