### PR TITLE
Add CI workflow to run unit tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run unit tests
+        run: pytest tests/unit/ -v --tb=short


### PR DESCRIPTION
## Summary

- Add `ci.yml` workflow triggered on every PR
- Runs `pytest tests/unit/ -v` with Python 3.12
- No existing workflow runs unit tests — this fills that gap

## Context

Part of [AI Bug Automation Readiness](https://github.com/ugiordan/ai-bug-automation-readiness/blob/main/docs/TEAM_ACTION_GUIDE.md) assessment — Task 13: CI Runs Tests on PRs.

Existing workflows cover formatting (`validate-python.yml`), notebook validation (`validate-notebooks.yml`), and pipeline compilation (`compile-kfp.yml`), but none run unit tests.

## Test plan

- [ ] Workflow YAML is valid
- [ ] CI triggers on PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)