### PR TITLE
Add code coverage configuration for KFP common module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 .env
 venv
 diagrams/
+htmlcov/
+coverage.xml
+.coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,26 @@ lint.ignore = ["E203","E501","UP006","UP007","UP035"]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = ["--tb=short", "-v"]
+
+[tool.coverage.run]
+source = [
+  "kubeflow-pipelines/common",
+]
+omit = [
+  "tests/*",
+  "*/__pycache__/*",
+  "*/local_run.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_empty = true
+fail_under = 40
+exclude_lines = [
+  "pragma: no cover",
+  "if __name__ == .__main__.",
+  "if TYPE_CHECKING:",
+]
+
+[tool.coverage.html]
+directory = "htmlcov"


### PR DESCRIPTION
## Summary

- Configure `pytest-cov` in `pyproject.toml` for `kubeflow-pipelines/common/`
- Set 40% minimum threshold (`fail_under = 40`)
- Add coverage artifacts to `.gitignore` (htmlcov/, .coverage, coverage.xml)

## Context

Part of [AI Bug Automation Readiness](https://github.com/ugiordan/ai-bug-automation-readiness/blob/main/docs/TEAM_ACTION_GUIDE.md) assessment — Task 14: Coverage Configuration.

The 40% floor is pragmatic — KFP components run inside containers with dependencies (docling, boto3) not available locally.

## Test plan

- [ ] `pytest tests/unit/ --cov --cov-report=term-missing` shows coverage
- [ ] `make coverage` generates HTML report in `htmlcov/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)