### PR TITLE
Add ruff linting to validate-python CI workflow

### DIFF
--- a/.github/workflows/validate-python.yml
+++ b/.github/workflows/validate-python.yml
@@ -1,4 +1,4 @@
-name: Python Formatting Validation
+name: Python Lint & Format
 
 on:
   workflow_dispatch:
@@ -9,35 +9,26 @@ on:
       - ".pre-commit-config.yaml"
       - "Makefile"
       - "pyproject.toml"
-      - ".github/workflow/validate-python.yml"
-  pull_request_target:
-    types: [closed]
-    paths:
-      - "**/*.py"
-      - ".pre-commit-config.yaml"
-      - "Makefile"
-      - "pyproject.toml"
-      - ".github/workflow/validate-python.yml"
+      - ".github/workflows/validate-python.yml"
 
 jobs:
-  formatting-test:
+  lint-and-format:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          # For pull_request_target on forks, ensure we check out the merge commit or default branch safely
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - name: Install python formatting test dependencies
+      - name: Install ruff
         run: pip install ruff
 
-      - name: Run Formatting Tests
+      - name: Run ruff linter
+        run: ruff check kubeflow-pipelines/
+
+      - name: Run ruff format check
         run: make format-python-check


### PR DESCRIPTION
## Summary

- Add `ruff check kubeflow-pipelines/` step to existing `validate-python.yml`
- Rename workflow from "Python Formatting Validation" to "Python Lint & Format"
- Remove `pull_request_target` trigger (security concern — runs untrusted code with repo permissions)
- Fix typo in paths filter (`.github/workflow/` → `.github/workflows/`)

## Context

Part of [AI Bug Automation Readiness](https://github.com/ugiordan/ai-bug-automation-readiness/blob/main/docs/TEAM_ACTION_GUIDE.md) assessment — Task 17: Linting in CI.

Previously, CI only ran \`ruff format --check\` (formatting) but not \`ruff check\` (linting). These catch different issues — formatting catches whitespace/style, linting catches unused imports (F401), undefined names (F821), mutable defaults (B006), etc.

## Test plan

- [ ] `ruff check kubeflow-pipelines/` passes locally
- [ ] CI triggers on PRs with `.py` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)