### PR TITLE
Expand CODEOWNERS with granular KFP pipeline ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,20 @@
-# Default owners for everything
-*  @opendatahub-io/odh-data-processing
+# CODEOWNERS — automatic reviewer assignment for PRs
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Rules are evaluated bottom-up: the last matching pattern takes precedence.
 
-# Keep the CODEOWNERS file itself owned by the team
-/.github/CODEOWNERS  @opendatahub-io/odh-data-processing
+# ── Default: core team owns everything ──────────────────────────────────
+*                                          @opendatahub-io/odh-data-processing
+
+# ── KFP Pipelines ─────────────────────────────────────────────────────
+kubeflow-pipelines/                        @opendatahub-io/odh-data-processing-pipelines
+
+# ── CI/CD & Repo Config ──────────────────────────────────────────────
+.github/                                   @opendatahub-io/odh-data-processing
+.pre-commit-config.yaml                    @opendatahub-io/odh-data-processing
+Makefile                                   @opendatahub-io/odh-data-processing
+pyproject.toml                             @opendatahub-io/odh-data-processing
+requirements-dev.txt                       @opendatahub-io/odh-data-processing
+
+# ── Protected files ───────────────────────────────────────────────────
+.github/CODEOWNERS                         @opendatahub-io/odh-data-processing


### PR DESCRIPTION
## Summary

- Expand existing `.github/CODEOWNERS` with granular ownership
- `kubeflow-pipelines/` → `@opendatahub-io/odh-data-processing-pipelines`
- CI/CD config files (`.github/`, `Makefile`, `pyproject.toml`) → core team
- CODEOWNERS itself requires core team approval

**Note**: Team names are placeholders. Adjust to match actual GitHub team slugs.

## Context

Part of [AI Bug Automation Readiness](https://github.com/ugiordan/ai-bug-automation-readiness/blob/main/docs/TEAM_ACTION_GUIDE.md) assessment — Task 19: Code Ownership.

## Test plan

- [ ] GitHub recognizes CODEOWNERS syntax
- [ ] PRs touching `kubeflow-pipelines/` auto-request pipelines team review

🤖 Generated with [Claude Code](https://claude.com/claude-code)