### PR TITLE
Add pull request template with KFP testing checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+## Description
+
+<!-- What does this PR do? Link the related issue(s). -->
+
+Fixes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactoring (no behavior change)
+- [ ] Documentation
+- [ ] CI/CD or tooling
+- [ ] Pipeline component change
+
+## Testing Checklist
+
+<!-- Check all that apply. CI will also run these automatically. -->
+
+- [ ] `make lint` passes (ruff lint + format check)
+- [ ] New/modified code has tests in `tests/unit/`
+
+### If you changed KFP pipelines or components:
+
+- [ ] Recompiled YAML and committed it (`python *_convert_pipeline.py`)
+- [ ] Tested locally with `local_run.py` (or confirmed CI will cover it)
+
+### If you changed dependencies:
+
+- [ ] Updated the correct scoped `requirements.txt` (not a monolithic file)
+- [ ] Pinning strategy matches existing pattern (exact for KFP, floor for dev tools)
+
+## Test Evidence
+
+<!-- Paste relevant output from test runs, screenshots, or logs. -->
+<!-- For AI-generated PRs: include the full test command and output. -->
+
+```
+<paste test output here>
+```
+
+## Additional Context
+
+<!-- Anything else reviewers should know? Breaking changes, migration steps, etc. -->


### PR DESCRIPTION
## Summary

- Add `.github/PULL_REQUEST_TEMPLATE.md` with structured sections
- Testing checklist covers `make lint` and unit tests
- Conditional sections for pipeline changes and dependency changes
- Test evidence section for pasting output (important for AI-generated PRs)

## Context

Part of [AI Bug Automation Readiness](https://github.com/ugiordan/ai-bug-automation-readiness/blob/main/docs/TEAM_ACTION_GUIDE.md) assessment — Task 20: PR Template.

## Test plan

- [ ] New PRs show the template automatically
- [ ] All checklist items are relevant and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)