### PR TITLE
Upgrade KFP to 2.16.1 and increase pipeline timeout

### DIFF
--- a/.github/workflows/execute-kfp-localrunners.yml
+++ b/.github/workflows/execute-kfp-localrunners.yml
@@ -127,12 +127,12 @@ jobs:
       - name: Install minimal requirements
         run: |
           # Setup Pip
-          /usr/bin/python3.11 -m ensurepip --upgrade >/dev/null 2>&1 
-          /usr/bin/python3.11 -m pip install --upgrade pip 
-          
+          /usr/bin/python3.11 -m ensurepip --upgrade >/dev/null 2>&1
+          /usr/bin/python3.11 -m pip install --upgrade pip
+
           # 1. Install Requirements (Generic)
           # We do this first so we can overwrite any bad CPU-versions it pulls in
-          /usr/bin/python3.11 -m pip install docker kfp==2.14.6    
+          /usr/bin/python3.11 -m pip install docker kfp==2.16.1    
       - name: Create output directory
         working-directory: kubeflow-pipelines/${{ matrix.pipeline }}
         run: |

--- a/.github/workflows/execute-kfp-localrunners.yml
+++ b/.github/workflows/execute-kfp-localrunners.yml
@@ -146,7 +146,7 @@ jobs:
          password: ${{ secrets.QUAY_PASSWORD }}
       
       - name: Run local pipeline
-        timeout-minutes: 15
+        timeout-minutes: 30
         working-directory: kubeflow-pipelines/${{ matrix.pipeline }}
         run: |
           # Only set env vars if inputs are provided (non-empty)


### PR DESCRIPTION
## Summary
This PR addresses two issues with the local pipeline test runner:

1. **Upgrades KFP from 2.14.6 to 2.16.1** to fix compatibility with newer Docling images
2. **Increases pipeline timeout from 15 to 30 minutes** to accommodate VLM model downloads

## Problem
The `test-local-pipelines` workflow was failing when using `quay.io/aipcc/docling/sdk-cuda-ubi9:3.5.0-ea.2` with two errors:

### Error 1: KFP Version Mismatch
```
ERROR: Could not find a version that satisfies the requirement kfp==2.14.6 (from versions: 2.16.1)
ERROR: No matching distribution found for kfp==2.14.6
```

The newer Docling CUDA image only provides KFP 2.16.1 in its Python environment.

### Error 2: Timeout During Model Download
```
Error: The action 'Run local pipeline' has timed out after 15 minutes.
```

The VLM pipeline downloads SmolVLM and smoldocling models from HuggingFace, which includes multiple ONNX variants. These downloads were timing out at 15 minutes.

## Changes
- `.github/workflows/execute-kfp-localrunners.yml`:
  - Updated KFP version from 2.14.6 to 2.16.1 (line 135)
  - Increased timeout from 15 to 30 minutes (line 149)
  - Minor whitespace cleanup

## Testing
- [x] Tested with `quay.io/aipcc/docling/sdk-cuda-ubi9:3.5.0-ea.2`
- [x] Both docling-standard and docling-vlm pipelines complete successfully

## Notes
The 30-minute timeout should be sufficient for VLM model downloads even with unauthenticated HuggingFace access. For faster downloads in production, consider setting `HF_TOKEN` for authenticated access.